### PR TITLE
Speedometer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 BUILDDIR:=build
 
-.PHONY: setup compile install uninstall clean
+.PHONY: setup compile install uninstall clean debug release
 
 all: compile
 
@@ -16,11 +16,15 @@ compile: $(BUILDDIR)
 local: $(BUILDDIR)
 	meson configure -Dprefix=${HOME}/.local $(BUILDDIR)
 
+debug release: $(BUILDDIR)
+	meson configure --buildtype $@ $(BUILDDIR)
+	$(MAKE) compile
+
 install: compile
 	meson install -C $(BUILDDIR)
 
-uninstall:
+uninstall: $(BUILDDIR)
 	cd $(BUILDDIR) && meson --internal uninstall
 
-test:
-	meson test -C $(BUILDDIR)
+test: compile
+	meson test -C $(BUILDDIR) -v --suite default

--- a/meson.build
+++ b/meson.build
@@ -21,6 +21,7 @@ tmio_dep = declare_dependency(include_directories : tmio_inc, link_with : tmio_l
 
 subdir('examples')
 
+subdir('tests')
+
 pkg_mod = import('pkgconfig')
 pkg_mod.generate(tmio_lib)
-

--- a/src/tmio.c
+++ b/src/tmio.c
@@ -146,6 +146,9 @@ typedef struct {
   int datamissing;
   int dataskipped;
   int tagsskipped;
+  unsigned long byteswritten;
+  unsigned long bytesread;
+  unsigned long bytesskipped;
 } tmio_stream;
 
 /*++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*/
@@ -304,6 +307,9 @@ Returns 0.
   stream->datamissing = 0;
   stream->dataskipped = 0;
   stream->tagsskipped = 0;
+  stream->byteswritten = 0;
+  stream->bytesread = 0;
+  stream->bytesskipped = 0;
 
   return 0;
 }
@@ -396,6 +402,7 @@ TMIO_EHANDSHAKE Error while writing protocol
     tmio_close(stream);
     return -1;
   }
+  stream->byteswritten += sizeof(protocol_tag) + TMIO_PROTOCOL_SIZE;
 
   if (stream->debug > 1)
     fprintf(stderr, "tmio_create: connected file/peer %s\n", name);
@@ -468,6 +475,7 @@ TMIO_EPROTO     Protocols do not match
     tmio_close(stream);
     return -1;
   }
+  stream->bytesread += sizeof(protocol_tag) + TMIO_PROTOCOL_SIZE;
 
   // Sanitise input
   protocol[TMIO_PROTOCOL_SIZE - 1] = 0;
@@ -546,6 +554,7 @@ TMIO_ETIMEDOUT Write operation timed out
 
   stream->state |= TMIO_WRITING;
   stream->tagwrites++;
+  stream->byteswritten += sizeof(write_tag);
   return 0;
 }
 
@@ -592,6 +601,7 @@ reads (tmio_read_data returns 0) on the other end.
   }
 
   stream->datawrites++;
+  stream->byteswritten += sizeof(size) + size;
   return size;
 }
 
@@ -693,6 +703,7 @@ static int tmio_skip_frame(tmio_stream *stream)
   if (frame_header < 0) {
     // Skip tag
     stream->tagsskipped++;
+    stream->bytesskipped += sizeof(frame_header);
   } else {
     // Skip data frame
     int remaining_bytes = frame_header;
@@ -709,8 +720,8 @@ static int tmio_skip_frame(tmio_stream *stream)
       assert(nbytes <= remaining_bytes);
       remaining_bytes -= nbytes;
     }
-
     stream->dataskipped++;
+    stream->bytesskipped += sizeof(frame_header) + frame_header;
   }
 
   return 0;
@@ -821,6 +832,7 @@ TMIO_ETIMEDOUT A timeout occured while skipping a data frame
       stream->hasbufferedheader = 0;
       stream->bufferedheader = 0;
       stream->tagreads++;
+      stream->bytesread += sizeof(tag);
       return tag;
     }
 
@@ -851,6 +863,7 @@ TMIO_ETIMEDOUT A timeout occured while skipping a data frame
       return -1;
   }
 
+  stream->bytesread += sizeof(frame_header);
   stream->tagreads++;
   return -frame_header;
 }
@@ -915,6 +928,7 @@ TMIO_ETIMEDOUT The timeout was hit before a complete data frame could be read
   }
 
   // Update statistics
+  stream->bytesread += sizeof(*frame_header) + to_read;
   stream->datareads++;
   if (frame_size > size)
     stream->datatruncs++;
@@ -932,6 +946,7 @@ TMIO_ETIMEDOUT The timeout was hit before a complete data frame could be read
       tmio_set_status(stream, TMIO_EREAD);
       return -1;
     }
+    stream->bytesskipped += nbytes;
 
     assert(nbytes <= remaining_bytes);
     remaining_bytes -= nbytes;
@@ -1080,6 +1095,9 @@ Prints statistics.
   fprintf(stderr, "... read truncated   %d\n", stream->datatruncs);
   fprintf(stderr, "... data skipped     %d\n", stream->dataskipped);
   fprintf(stderr, "... tags skipped     %d\n", stream->tagsskipped);
+  fprintf(stderr, "... bytes written    %zu\n", stream->byteswritten);
+  fprintf(stderr, "... bytes read       %zu\n", stream->bytesread);
+  fprintf(stderr, "... bytes skipped    %zu\n", stream->bytesskipped);
 
   return 0;
 }

--- a/src/tmio.h
+++ b/src/tmio.h
@@ -75,6 +75,9 @@ typedef struct {
   int datamissing;
   int dataskipped;
   int tagsskipped;
+  unsigned long byteswritten;
+  unsigned long bytesread;
+  unsigned long bytesskipped;
 } tmio_stream;
 
 tmio_stream *tmio_init(const char *protocol, int protocol_timeout, int bufkb,

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,0 +1,3 @@
+tmio_test_statistics = executable('tmio_test_statistics', 'tmio_test_statistics.c', dependencies : [tmio_dep])
+
+test('tmio_test_statistics', tmio_test_statistics, is_parallel : true, args : ['tmio_test_statistics.dat'], suite: ['all', 'default'])

--- a/tests/test.h
+++ b/tests/test.h
@@ -1,0 +1,9 @@
+#include <stdio.h>
+#include <unistd.h>
+
+#define assert(e) if (!(e)) { fprintf(stderr, "Assertion failed: %s, function %s, file %s, line %d.\n", #e, __func__, __FILE__, __LINE__); _exit(1); }
+
+// Three macros to simplify creation of forks and to check for a clean exit of the child process; use in this order
+#define FORK_CHILD if (fork() == 0) {
+#define FORK_PARENT _exit(0); } else {
+#define FORK_JOIN int status; wait(&status); assert(WIFEXITED(status)); if (WEXITSTATUS(status) != 0) return 1; }

--- a/tests/tmio_test_statistics.c
+++ b/tests/tmio_test_statistics.c
@@ -1,0 +1,154 @@
+#include "tmio.h"
+
+#include "test.h"
+
+#include <sys/stat.h>
+
+const int protocol_timeout = 3000;  // ms
+const int connect_timeout = -1;  // indefinite
+const int wait_timeout = 0;  // immediate
+const int verbosity = 3;  // 0...3 (silent...very verbose)
+const int debug = 0;
+const int buffersize = 0;  // 0: default size, >0: kByte
+const char* peer = "tmio_test_statistics.dat";
+
+#define TAG 1
+#define LONG_MSG_SIZE (2)
+#define SHORT_MSG_SIZE (LONG_MSG_SIZE/2)
+
+const size_t frame_header_size = sizeof(int);
+char buffer[LONG_MSG_SIZE] = {0};
+
+unsigned long filesize(const char* filename) {
+  struct stat st;
+  stat(filename, &st);
+  return st.st_size;
+}
+
+void main_writer(const char* name, const char* peer)
+{
+  unsigned long exp_written_bytes = 0;
+  int exp_written_tags = 0;
+  int exp_written_data = 0;
+
+  tmio_stream *stream = tmio_init(name, protocol_timeout, buffersize, verbosity);
+  assert(tmio_create(stream, peer, connect_timeout) == TMIO_FILE);
+
+  // 0. check init protocol size
+  assert(stream->byteswritten == (exp_written_bytes += frame_header_size + TMIO_PROTOCOL_SIZE));
+
+  // 1. check tag size
+  tmio_write_tag(stream, TAG);
+  assert(stream->byteswritten == (exp_written_bytes += frame_header_size));
+  assert(stream->tagwrites == (exp_written_tags += 1));
+
+  // 3. check datashort : reading less than requested
+  tmio_write_data(stream, buffer, LONG_MSG_SIZE);
+  assert(stream->byteswritten == (exp_written_bytes += frame_header_size + LONG_MSG_SIZE));
+  assert(stream->datawrites == (exp_written_data += 1));
+
+  // 3. check reading beyond SHORT_MSG_SIZE
+  tmio_write_data(stream, buffer, SHORT_MSG_SIZE);
+  assert(stream->byteswritten == (exp_written_bytes += frame_header_size + SHORT_MSG_SIZE));
+  assert(stream->datawrites == (exp_written_data += 1));
+
+  // 4. check datatrunc : reading more than expected, skipping non-requested
+  tmio_write_data(stream, buffer, LONG_MSG_SIZE);
+  assert(stream->byteswritten == (exp_written_bytes += frame_header_size + LONG_MSG_SIZE));
+  assert(stream->datawrites == (exp_written_data += 1));
+
+  // 5. check dataskip : looking for a tag, but there is still data left
+  tmio_write_data(stream, buffer, SHORT_MSG_SIZE);
+  assert(stream->byteswritten == (exp_written_bytes += frame_header_size + SHORT_MSG_SIZE));
+  assert(stream->datawrites == (exp_written_data += 1));
+
+  tmio_write_tag(stream, TAG);
+  assert(stream->byteswritten == (exp_written_bytes += frame_header_size));
+  assert(stream->tagwrites == (exp_written_tags += 1));
+
+  // 6. check datamissing : reading non-existant data until following tag
+  tmio_write_tag(stream, TAG);
+  assert(stream->byteswritten == (exp_written_bytes += frame_header_size));
+  assert(stream->tagwrites == (exp_written_tags += 1));
+
+  // -1. check on-disk size
+  tmio_flush(stream);
+  assert(stream->byteswritten == filesize(peer));
+  assert(stream->flushes == 1);
+
+  tmio_delete(stream);
+}
+
+void main_reader(const char* name, const char* peer)
+{
+  unsigned long exp_read_bytes = 0;
+  unsigned long exp_skipped_bytes = 0;
+  int exp_read_tags = 0;
+  int exp_read_data = 0;
+
+  tmio_stream *stream = tmio_init(name, protocol_timeout, buffersize, verbosity);
+  assert(tmio_open(stream, peer, connect_timeout) == TMIO_FILE);
+
+  // 0. check init protocol size
+  assert(stream->bytesread == (exp_read_bytes += frame_header_size + TMIO_PROTOCOL_SIZE));
+
+  // 1. check tag size
+  assert(tmio_read_tag(stream) == TAG);
+  assert(stream->bytesread == (exp_read_bytes += frame_header_size));
+  assert(stream->tagreads == (exp_read_tags += 1));
+
+  // 2. check data size
+  assert(tmio_read_data(stream, buffer, LONG_MSG_SIZE) == LONG_MSG_SIZE);
+  assert(stream->bytesread == (exp_read_bytes += frame_header_size + LONG_MSG_SIZE));
+  assert(stream->datareads == (exp_read_data += 1));
+
+  // 3. check datashort : reading less than requested
+  assert(stream->datashorts == 0);
+  assert(tmio_read_data(stream, buffer, LONG_MSG_SIZE) == SHORT_MSG_SIZE);
+  assert(stream->bytesread == (exp_read_bytes += frame_header_size + SHORT_MSG_SIZE));
+  assert(stream->datareads == (exp_read_data += 1));
+  assert(stream->datashorts == 1);
+
+  // 4. check datatrunc : reading more than expected, skipping non-requested
+  assert(stream->datatruncs == 0);
+  assert(tmio_read_data(stream, buffer, SHORT_MSG_SIZE) == LONG_MSG_SIZE);
+  assert(stream->bytesread == (exp_read_bytes += frame_header_size + SHORT_MSG_SIZE));
+  assert(stream->bytesskipped == (exp_skipped_bytes += SHORT_MSG_SIZE));
+  assert(stream->datareads == (exp_read_data += 1));
+  assert(stream->datatruncs == 1);
+
+  // 5. check dataskip : looking for a tag, but there is still data left
+  assert(stream->dataskipped == 0);
+  assert(tmio_read_tag(stream) == TAG);
+  assert(stream->bytesread == (exp_read_bytes += frame_header_size));
+  assert(stream->bytesskipped == (exp_skipped_bytes += frame_header_size + SHORT_MSG_SIZE));
+  assert(stream->tagreads == (exp_read_tags += 1));
+  assert(stream->dataskipped == 1);
+
+  // 6. check datamissing : reading non-existant data until following tag
+  assert(stream->datamissing == 0);
+  assert(tmio_read_data(stream, buffer, SHORT_MSG_SIZE) == -2);
+  assert(stream->datamissing == 1);
+  assert(tmio_read_tag(stream) == TAG);
+  assert(stream->bytesread == (exp_read_bytes += frame_header_size));
+  assert(stream->tagreads == (exp_read_tags += 1));
+
+  // -1. check on-disk size
+  assert(stream->bytesread + stream->bytesskipped == filesize(peer));
+
+  tmio_delete(stream);
+}
+
+
+int main(int argc, const char* argv[])
+{
+  if (argc < 2)
+    return 1;
+
+  main_writer(argv[0], argv[1]);
+  main_reader(argv[0], argv[1]);
+
+  remove(argv[1]);
+
+  return 0;
+}


### PR DESCRIPTION
Add monitoring of stream throughput (on-disk/stream size) to the statistics, namely 3 new observables: `bytes<written/read/skipped>`. 

Adds a test invoking scenarios resulting in all stat variables being used at least once.

It would be possible to only measure data itself, and calculate the observables in this PR using the write/read/missing counters for tags and data to determine the on-disk size; it might however be more error prone and requires more knowledge about the library internals.

Alternatively it would be possible to more statistic variables (later?) which offer the data sizes in bytes. Not sure about consistent naming though. 
<streambytes> vs <databytes>?